### PR TITLE
Environments that support non fixed bet size

### DIFF
--- a/.github/workflows/testpackage.yml
+++ b/.github/workflows/testpackage.yml
@@ -30,7 +30,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pip install pytest pytest-cov coveralls
+        pip install pytest pytest-cov coveralls pandas
         pytest -v tests --cov=oddsgym
     - name: Post to Coveralls.io
       env:

--- a/oddsgym/envs/base_percentage.py
+++ b/oddsgym/envs/base_percentage.py
@@ -1,0 +1,16 @@
+import numpy
+from gym import spaces
+from .base import BaseOddsEnv
+
+class BasePercentageGamblingEnv(BaseOddsEnv):
+    """Base class for sports betting environments supporting non fixed bet size"""
+
+    def __init__(self, odds, odds_column_names, results=None):
+        super().__init__(odds, odds_column_names, results)
+        self.action_space = spaces.Box(low=numpy.array([0., 0.01]),
+                                       high=numpy.array([self.action_space.n - 0.01, 1 / odds.shape[1]]))
+
+    def step(self, action):
+        form = int(numpy.floor(action[0]))
+        self.single_bet_size = action[1] * self.balance
+        return super().step(form)

--- a/oddsgym/envs/soccer.py
+++ b/oddsgym/envs/soccer.py
@@ -1,4 +1,5 @@
 from .base import BaseOddsEnv
+from .base_percentage import BasePercentageGamblingEnv
 
 class ThreeWaySoccerOddsEnv(BaseOddsEnv):
     """Environment for 3-way soccer betting"""
@@ -10,7 +11,12 @@ class ThreeWaySoccerOddsEnv(BaseOddsEnv):
         super().__init__(odds, odds_column_names, results)
         self.teams = soccer_bets_dataframe[['home_team', 'away_team']].values
 
-    def render(self, mode='human'):
+    def render(self, mode='human'):  # pragma: no cover
         return 'Home Team {} VS Away Team {}. {}'.format(self.teams[self.current_step % self._odds.shape[0]][0],
                                                          self.teams[self.current_step % self._odds.shape[0]][1],
                                                          super().render(mode))
+
+
+class ThreeWaySoccerPercentageOddsEnv(ThreeWaySoccerOddsEnv, BasePercentageGamblingEnv):
+    """Environment for 3-way soccer betting with non fixed bet size"""
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,26 @@
 from pytest import fixture
 from numpy import array
+from pandas import DataFrame
 from oddsgym.envs.base import BaseOddsEnv
+from oddsgym.envs.base_percentage import BasePercentageGamblingEnv
+from oddsgym.envs.soccer import ThreeWaySoccerOddsEnv, ThreeWaySoccerPercentageOddsEnv
 
 @fixture()
 def basic_env(request):
-    return BaseOddsEnv(array([[1, 2]]), ['w', 'l'], [1, 1])
+    return BaseOddsEnv(array([[1, 2], [3, 4]]), ['w', 'l'], [1, 0])
+
+@fixture()
+def basic_percentge_env(request):
+    return BasePercentageGamblingEnv(array([[2, 1]]), ['w', 'l'], [0])
+
+@fixture()
+def three_way_env(request):
+    soccer_bets_dataframe = DataFrame([{'home_team': 'FCB', 'away_team': 'PSG', 'home': 1, 'draw': 2, 'away': 3, 'result': 1},
+                                       {'home_team': 'MCB', 'away_team': 'MTA', 'home': 4, 'draw': 3, 'away': 2, 'result': 0}])
+    return ThreeWaySoccerOddsEnv(soccer_bets_dataframe)
+
+@fixture()
+def three_way_percentage_env(request):
+    soccer_bets_dataframe = DataFrame([{'home_team': 'FCB', 'away_team': 'PSG', 'home': 1, 'draw': 2, 'away': 3, 'result': 1},
+                                       {'home_team': 'MCB', 'away_team': 'MTA', 'home': 4, 'draw': 3, 'away': 2, 'result': 0}])
+    return ThreeWaySoccerPercentageOddsEnv(soccer_bets_dataframe)

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -7,10 +7,41 @@ def test_attributes(basic_env):
     assert basic_env.STARTING_BANK == 10
     assert basic_env.balance == basic_env.STARTING_BANK
     assert basic_env.current_step == 0
+    assert basic_env.single_bet_size == 1
 
 @pytest.mark.parametrize("action,expected_reward", [(0, 0), (1, -1), (2, 1), (3, 0)])
 def test_step(basic_env, action, expected_reward):
     odds, reward, done, _ = basic_env.step(action)
     assert reward == expected_reward
+    assert not done
+    assert basic_env.current_step == 1
+
+def test_reset(basic_env):
+    odds, reward, done, _ = basic_env.step(2)
+    assert reward == 1
+    assert basic_env.balance == basic_env.STARTING_BANK + 1
+    assert not done
+    assert basic_env.current_step == 1
+    odds, reward, done, _ = basic_env.step(1)
+    assert reward == 2
     assert done
+    basic_env.reset()
+    assert basic_env.balance == basic_env.STARTING_BANK
+
+def test_render(basic_env):
+    assert basic_env.render() == "Current balance at step {}: {}".format(basic_env.current_step, basic_env.balance)
+
+@pytest.mark.parametrize("action", range(4))
+def test_step_when_balance_is_0(basic_env, action):
+    basic_env.balance = 0
+    odds, reward, done, _ = basic_env.step(action)
+    assert reward == 0
+    assert done
+    assert basic_env.current_step == 0
+
+def test_step_illegal_action(basic_env):
+    basic_env.balance = 1
+    odds, reward, done, _ = basic_env.step(3)  # illegal - making a double when when the balance is 1
+    assert reward == -2
+    assert not done
     assert basic_env.current_step == 0

--- a/tests/test_base_percentage.py
+++ b/tests/test_base_percentage.py
@@ -1,0 +1,19 @@
+import pytest
+import numpy
+from gym.spaces import Box
+
+def test_attributes(basic_percentge_env):
+    assert basic_percentge_env.action_space == Box(low=numpy.array([0., 0.01]),
+                                                   high=numpy.array([2 ** 2 - 0.01, 0.5]))
+    assert basic_percentge_env.observation_space == Box(low=1., high=float('Inf'), shape=(2,))
+    assert basic_percentge_env.STARTING_BANK == 10
+    assert basic_percentge_env.balance == basic_percentge_env.STARTING_BANK
+    assert basic_percentge_env.current_step == 0
+    assert basic_percentge_env.single_bet_size == 1
+
+@pytest.mark.parametrize("action,expected_reward", [((0, 0.25), 0), ((1, 0.25), 2.5), ((2, 0.25), -2.5), ((3, 0.25), 0)])
+def test_step(basic_percentge_env, action, expected_reward):
+    odds, reward, done, _ = basic_percentge_env.step(action)
+    assert reward == expected_reward
+    assert done
+    assert basic_percentge_env.current_step == 0

--- a/tests/test_three_way_env.py
+++ b/tests/test_three_way_env.py
@@ -1,0 +1,32 @@
+import pytest
+import numpy
+from gym.spaces import Box
+
+def test_attributes(three_way_env):
+    assert three_way_env.action_space.n == 2 ** 3
+    assert three_way_env.observation_space == Box(low=1., high=float('Inf'), shape=(3,))
+    assert three_way_env.STARTING_BANK == 10
+    assert three_way_env.balance == three_way_env.STARTING_BANK
+    assert three_way_env.current_step == 0
+    assert three_way_env.single_bet_size == 1
+    assert numpy.array_equal(three_way_env.teams, numpy.array([['FCB', 'PSG'], ['MCB', 'MTA']]))
+
+@pytest.mark.parametrize("action,expected_reward", [(0, 0), (1, -1), (2, 1), (3, -1), (4, 0), (5, -2), (6, 0), (7, -1)])
+def test_step(three_way_env, action, expected_reward):
+    odds, reward, done, _ = three_way_env.step(action)
+    assert reward == expected_reward
+    assert not done
+    assert three_way_env.current_step == 1
+
+def test_multiple_steps(three_way_env):
+    odds, reward, done, _ = three_way_env.step(3)
+    assert reward == -1
+    assert three_way_env.balance == three_way_env.STARTING_BANK - 1
+    assert not done
+    assert three_way_env.current_step == 1
+    odds, reward, done, _ = three_way_env.step(1)
+    assert reward == 3
+    assert three_way_env.balance == three_way_env.STARTING_BANK - 1 + 3
+    assert done
+
+

--- a/tests/test_three_way_percentage_env.py
+++ b/tests/test_three_way_percentage_env.py
@@ -1,0 +1,18 @@
+import pytest
+import numpy
+from gym.spaces import Box
+
+def test_attributes(three_way_percentage_env):
+    assert three_way_percentage_env.observation_space == Box(low=1., high=float('Inf'), shape=(3,))
+    assert three_way_percentage_env.action_space == Box(low=numpy.array([0., 0.01]),
+                                                   high=numpy.array([2 ** 3 - 0.01, 1 / 3]))
+    assert numpy.array_equal(three_way_percentage_env.teams, numpy.array([['FCB', 'PSG'], ['MCB', 'MTA']]))
+
+@pytest.mark.parametrize("action,expected_reward", [((0, 0.1), 0), ((1, 0.1), -1), ((2, 0.1), 1), ((3, 0.1), -1)])
+def test_step(three_way_percentage_env, action, expected_reward):
+    odds, reward, done, _ = three_way_percentage_env.step(action)
+    assert reward == expected_reward
+    assert not done
+    assert three_way_percentage_env.current_step == 1
+
+


### PR DESCRIPTION
Add environments in which the action space in no longer only discrete, but now is a gym.spaces.Box of shape (2,) in which the first coordinate is the bet to place and the second coordinate is the percentage of the current balance to place as the bet.