### PR TITLE
Render environments with rich tables if using render_mode="human"

### DIFF
--- a/oddsgym/envs/daily_bets.py
+++ b/oddsgym/envs/daily_bets.py
@@ -49,12 +49,8 @@ class DailyOddsEnv(BaseOddsEnv):
         "Date",
         "Current Step",
         "Odds",
-        "Verbose Action",
-        "Action",
         "Balance",
         "Reward",
-        "Results",
-        "Done",
     ]
 
     def __init__(
@@ -281,13 +277,14 @@ class DailyOddsEnv(BaseOddsEnv):
             The info dictionary.
         """
         return {
-            "date": self.days[self.current_step],
+            "date": self.days[self.current_step].strftime("%Y-%m-%d"),
             "current_step": self.current_step,
             "odds": self.get_odds(),
             "verbose_action": [
                 self._verbose_actions[act] for act in numpy.floor(action).astype(int)
             ],
             "action": action,
+            "bet": self.get_bet(action),
             "balance": self.balance,
             "reward": 0,
             "legal_bet": False,

--- a/oddsgym/envs/footballdata.py
+++ b/oddsgym/envs/footballdata.py
@@ -150,7 +150,7 @@ class FootballDataDailyEnv(FootballDataMixin, ThreeWaySoccerOddsEnv):
             inplace=True,
         )
         super().__init__(
-            odds_dataframe[self.ENV_COLUMNS + self.ODDS_COLUMNS], **env_config
+            odds_dataframe[self.ENV_COLUMNS + self.ODDS_COLUMNS], **env_config, **kwargs
         )
         self._extra_odds = odds_dataframe
         self._extra = extra

--- a/oddsgym/envs/soccer.py
+++ b/oddsgym/envs/soccer.py
@@ -32,28 +32,22 @@ class ThreeWaySoccerOddsEnv(metaclass=MetaEnvBuilder):
             odds = odds.values
             results = results.values
         self.teams = soccer_bets_dataframe[["home_team", "away_team"]]
+        self.HEADERS.insert(2, "Teams")
         super().__init__(odds, self.odds_column_names, results, *args, **kwargs)
 
-    def render(self, mode="human"):
-        """Outputs the current team names, balance and step.
-
-        Returns
-        -------
-        msg : str
-            A string with the current team names, balance and step.
-        """
+    def create_info(self, action):
+        info = super().create_info(action)
         index = self._get_current_index()
         teams = self.teams.iloc[index]
         teams = teams.itertuples() if isinstance(teams, pandas.DataFrame) else [teams]
-        teams_str = ", ".join(
+        teams_str = "\n".join(
             [
-                "Home Team {} VS Away Team {}".format(row.home_team, row.away_team)
+                f"[blue]{row.home_team}[/] VS [magenta]{row.away_team}[/]"
                 for row in teams
             ]
         )
-        teams_str = teams_str + "."
-        print(teams_str)
-        super().render(mode)
+        info.update(teams=teams_str)
+        return info
 
 
 class ThreeWaySoccerPercentageOddsEnv(ThreeWaySoccerOddsEnv):

--- a/oddsgym/envs/tennis.py
+++ b/oddsgym/envs/tennis.py
@@ -32,27 +32,24 @@ class TennisOddsEnv(metaclass=MetaEnvBuilder):
             odds = odds.values
             results = results.values
         self.players = tennis_bets_dataframe[["winner", "loser"]]
+        self.HEADERS.insert(2, "Players")
         super().__init__(odds, self.odds_column_names, results, *args, **kwargs)
 
-    def render(self, mode="human"):
-        """Outputs the current player names, balance and step.
-
-        Returns
-        -------
-        msg : str
-            A string with the current player names, balance and step.
-        """
+    def create_info(self, action):
+        info = super().create_info(action)
         index = self._get_current_index()
         players = self.players.iloc[index]
         players = (
             players.itertuples() if isinstance(players, pandas.DataFrame) else [players]
         )
-        players_str = ", ".join(
-            ["Player {} VS Player {}".format(row.winner, row.loser) for row in players]
+        players_str = "\n".join(
+            [
+                "[blue]{}[/] VS [magenta]{}[/]".format(row.winner, row.loser)
+                for row in players
+            ]
         )
-        players_str = players_str + "."
-        print(players_str)
-        super().render(mode)
+        info.update(players=players_str)
+        return info
 
 
 class TennisPercentageOddsEnv(TennisOddsEnv):

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -38,7 +38,7 @@ def test_reset(basic_env):
     assert not done
     assert basic_env.current_step == 1
     assert info["legal_bet"]
-    assert info["results"] == 1
+    assert numpy.array_equal(info["results"], numpy.array([[0.0, 1.0]]))
     assert info["reward"] == 1
     assert not info["done"]
     odds, reward, done, *_ = basic_env.step(2)
@@ -59,13 +59,13 @@ def test_info(basic_env):
     assert not info["legal_bet"]
     assert info["results"] is None
     assert not info["done"]
-    basic_env.pretty_print_info(info)
+    # basic_env.pretty_print_info(info)
 
 
-def test_render(basic_env):
+def test_render_render_mode_none(basic_env):
     with mock.patch("sys.stdout", new=io.StringIO()) as fake_stdout:
-        basic_env.render()
-    assert fake_stdout.getvalue() == "Current balance at step 0: 10\n"
+        assert basic_env.render() is None
+    assert fake_stdout.getvalue() == ""
 
 
 @pytest.mark.parametrize("action", range(4))

--- a/tests/test_daily_env.py
+++ b/tests/test_daily_env.py
@@ -294,4 +294,4 @@ def test_info(daily_bets_env):
     assert not info["legal_bet"]
     assert info["results"] is None
     assert not info["done"]
-    daily_bets_env.pretty_print_info(info)
+    # daily_bets_env.pretty_print_info(info)

--- a/tests/test_tennis_daily_env.py
+++ b/tests/test_tennis_daily_env.py
@@ -67,8 +67,4 @@ def test_multiple_steps(tennis_daily_env):
 def test_render(tennis_daily_env):
     with mock.patch("sys.stdout", new=io.StringIO()) as fake_stdout:
         tennis_daily_env.render()
-    assert fake_stdout.getvalue() == (
-        "Player Berrettini M. VS Player Harris A., "
-        "Player Berankis R. VS Player Carballes Baena R.."
-        "\nCurrent balance at step 0: 10\n"
-    )
+    assert fake_stdout.getvalue() == ""

--- a/tests/test_tennis_env.py
+++ b/tests/test_tennis_env.py
@@ -48,7 +48,4 @@ def test_multiple_steps(tennis_env):
 def test_render(tennis_env):
     with mock.patch("sys.stdout", new=io.StringIO()) as fake_stdout:
         tennis_env.render()
-    assert (
-        fake_stdout.getvalue()
-        == "Player Berrettini M. VS Player Harris A..\nCurrent balance at step 0: 10\n"
-    )
+    assert fake_stdout.getvalue() == ""

--- a/tests/test_three_way_daily_env.py
+++ b/tests/test_three_way_daily_env.py
@@ -123,7 +123,4 @@ def test_multiple_steps_non_uniform(three_way_daily_env_non_uniform):
 def test_render(three_way_daily_env_non_uniform):
     with mock.patch("sys.stdout", new=io.StringIO()) as fake_stdout:
         three_way_daily_env_non_uniform.render()
-    assert (
-        fake_stdout.getvalue() == "Home Team FCB VS Away Team PSG, "
-        "Home Team MCB VS Away Team MTA.\nCurrent balance at step 0: 10\n"
-    )
+    assert fake_stdout.getvalue() == ""

--- a/tests/test_three_way_env.py
+++ b/tests/test_three_way_env.py
@@ -46,7 +46,4 @@ def test_multiple_steps(three_way_env):
 def test_render(three_way_env):
     with mock.patch("sys.stdout", new=io.StringIO()) as fake_stdout:
         three_way_env.render()
-    assert (
-        fake_stdout.getvalue()
-        == "Home Team FCB VS Away Team PSG.\nCurrent balance at step 0: 10\n"
-    )
+    assert fake_stdout.getvalue() == ""


### PR DESCRIPTION
For debugging and monitoring, rendering is now being done through a rich table, where the odds for each step/game are displayed in this color legend:
* gray text - no bet was placed on this specific outcome (noop / no operation)
* yellow text - bet was placed on this outcome and on atleast 1 other outcome, and this was the result of the game (warning)
* green text - bet was placed only on this outcome and this was result of the game (success)
* red text - bet was placed on this outcome and this was not the result of the game (failure)